### PR TITLE
Revert variable signedness changes.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,7 @@ TESTS = \
 	tests/encode.sh \
 	tests/encode-b58c.sh \
 	tests/encode-fail.sh \
+	tests/encode-neg-index.sh \
 	tests/encode-small.sh
 SH_LOG_COMPILER = /bin/sh
 AM_TESTS_ENVIRONMENT = PATH='$(srcdir)':"$$PATH"; export PATH;

--- a/base58.c
+++ b/base58.c
@@ -15,6 +15,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include "libbase58.h"
 
@@ -145,7 +146,8 @@ bool b58enc(char *b58, size_t *b58sz, const void *data, size_t binsz)
 {
 	const uint8_t *bin = data;
 	int carry;
-	size_t i, j, size, high, zcount = 0;
+	ssize_t i, j, high, zcount = 0;
+	size_t size;
 	
 	while (zcount < binsz && !bin[zcount])
 		++zcount;

--- a/tests/encode-neg-index.sh
+++ b/tests/encode-neg-index.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# This input causes the loop iteration counter to go negative
+b58=$(echo '00CEF022FA' | xxd -r -p | base58)
+test x$b58 = x16Ho7Hs


### PR DESCRIPTION
In the line:

    for (carry = bin[i], j = size - 1; (j > high) || carry; --j)

my analysis missed that the compare (j > high) is always true when
high is 0 and j wraps around. So although the loop does not store
through a negative 'j' offset, it does require j to become negative
in order to terminate the loop in that case. My apologies.